### PR TITLE
Addition of home and sethome

### DIFF
--- a/src/net/micrlink/core/Core.java
+++ b/src/net/micrlink/core/Core.java
@@ -18,6 +18,7 @@ import net.micrlink.core.cmds.afkCmd;
 import net.micrlink.core.cmds.creativeCmd;
 import net.micrlink.core.cmds.devCmd;
 import net.micrlink.core.cmds.survivalCmd;
+import net.micrlink.core.cmds.homeCmd;
 import net.micrlink.core.cmds.togglehud;
 import net.micrlink.core.listener.PlayerBedEnter;
 import net.micrlink.core.listener.PlayerChat;
@@ -122,7 +123,7 @@ public class Core extends JavaPlugin {
 		if (yaw > 225 && yaw < 315)
 			dir = "E";
 
-		String message = "§6XYZ §f" + x + " " + y + " " + z + "    §6" + dir + "    " + h + ":" + m;
+		String message = "ï¿½6XYZ ï¿½f" + x + " " + y + " " + z + "    ï¿½6" + dir + "    " + h + ":" + m;
 		ActionBarAPI.sendActionBar(player, message);
 	}
 
@@ -142,6 +143,8 @@ public class Core extends JavaPlugin {
 		getCommand("dev").setExecutor(new devCmd());
 		getCommand("survival").setExecutor(new survivalCmd());
 		getCommand("togglehud").setExecutor(new togglehud());
+		getCommand("home").setExecutor(new homeCmd());
+		getCommmand("sethome").setExecutor(new homeCmd());
 	}
 
 	private void registerEvents() {

--- a/src/net/micrlink/core/cmds/homeCmd.java
+++ b/src/net/micrlink/core/cmds/homeCmd.java
@@ -32,7 +32,9 @@ public class homeCmd implements CommandExecuter {
 		if (cmd.getName().equalsIgnoreCase("sethome")) {
             if (sender instanceof Player) {
                 Player p = (Player) sender;
-                Location location = survivalManager.setHomeLocation(p)
+				Location location = survivalManager.setHomeLocation(p)
+				p.sendMessage("Set home location!");
+				return true;
             }
         }
        

--- a/src/net/micrlink/core/cmds/homeCmd.java
+++ b/src/net/micrlink/core/cmds/homeCmd.java
@@ -1,0 +1,41 @@
+package net.micrlink.core.cmds;
+
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import net.micrlink.core.Core;
+import net.micrlink.core.manager.SurvivalManager;
+
+public class homeCmd implements CommandExecuter {
+    @Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		SurvivalManager survivalManager = Core.getSurvivalManager();
+
+		if (cmd.getName().equalsIgnoreCase("home")) {
+			if (sender instanceof Player) {
+				Player p = (Player) sender;
+				Location location = survivalManager.getHomeLocation(p);
+				if (location == null) {
+					p.sendMessage(
+							"�cYou have no saved home location. If you think this is an error, you have a long walk back!");
+					return true;
+				}
+				p.teleport(location);
+				survivalManager.saveHomeLocation(p, null);
+				return true;
+			}
+        }
+        
+        if (cmd.getName().equalsIgnoreCase("sethome")) {
+            if (sender instanceof Player) {
+                Player p = (Player) sender;
+                Location location = survivalManager.setHomeLocation(p)
+            }
+        }
+		return false;
+	}
+
+}

--- a/src/net/micrlink/core/cmds/homeCmd.java
+++ b/src/net/micrlink/core/cmds/homeCmd.java
@@ -27,14 +27,15 @@ public class homeCmd implements CommandExecuter {
 				survivalManager.saveHomeLocation(p, null);
 				return true;
 			}
-        }
-        
-        if (cmd.getName().equalsIgnoreCase("sethome")) {
+		}
+		
+		if (cmd.getName().equalsIgnoreCase("sethome")) {
             if (sender instanceof Player) {
                 Player p = (Player) sender;
                 Location location = survivalManager.setHomeLocation(p)
             }
         }
+       
 		return false;
 	}
 

--- a/src/net/micrlink/core/manager/SurvivalManager.java
+++ b/src/net/micrlink/core/manager/SurvivalManager.java
@@ -29,6 +29,17 @@ public class SurvivalManager implements Listener {
 
 	}
 
+	public void saveHomeLocation(Player player) {
+		Location location = player.getLocation();
+		UserSettingsManager settings = Core.getUserSettingsManager();
+		settings.set(player, "home_location", Util.locToString(location));
+	}
+
+	public Location getHomeLocation(Player player) {
+		UserSettingsManager settings = Core.getUserSettingsManager();
+		return Util.getStringLocation((String) settings.get(player, "home_location", null));
+	}
+
 	@EventHandler
 	public void onPlayerTeleport(PlayerTeleportEvent e) {
 		Player p = e.getPlayer();
@@ -37,7 +48,7 @@ public class SurvivalManager implements Listener {
 
 		if (Core.SURVIVAL_WORLDS.contains(fromWorldName) && !Core.SURVIVAL_WORLDS.contains(toWorldName)) {
 			saveSurvivalLocation(p, e.getFrom());
-			p.sendMessage("§7Your survival location has been saved to file. To return there type §b/survival");
+			p.sendMessage("ï¿½7Your survival location has been saved to file. To return there type ï¿½b/survival");
 		}
 	}
 


### PR DESCRIPTION
A useful set of commands for players who travel long distances and get lost. /sethome sets the player's home location. /home teleports the player to that location. Still needed are handling for if the player does not have a home location set, but that can be resolved after some testing. 